### PR TITLE
Fixes python and php and adds missing wget package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM phusion/baseimage:latest
 MAINTAINER Stefan Siegl <stesie@brokenpipe.de>
 
 RUN apt-get update
-RUN apt-get -y install git subversion make g++ python curl php5-dev chrpath && apt-get clean
+RUN apt-get -y install git subversion make g++ python2.7 curl php7.0-dev chrpath wget && apt-get clean
+RUN ln -s /usr/bin/python2.7 /usr/bin/python
 
 # depot tools
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /usr/local/depot_tools


### PR DESCRIPTION
python2.7 is required as opposed to python3.x that comes as default; it needs to be linked to '/usr/bin/python' as well;
php7.0 is a default in ubuntu now and v8js supports it;
wget is required by v8 installer;